### PR TITLE
Allowing base 4.7.

### DIFF
--- a/picosat.cabal
+++ b/picosat.cabal
@@ -28,7 +28,7 @@ library
 
   ghc-options:        -Wall -O2 -fwarn-tabs
   cc-options:         -funroll-loops
-  build-depends:      base >=4.6 && <4.7
+  build-depends:      base >=4.6 && <4.8
   default-language:   Haskell2010
   Hs-source-dirs:     src
   Include-dirs:       cbits


### PR DESCRIPTION
How come it said this was tested with GHC 7.8.3, if base 4.7 wasn't allowed?
