### PR TITLE
Disable rusage on Windows.

### DIFF
--- a/picosat.cabal
+++ b/picosat.cabal
@@ -28,6 +28,8 @@ library
 
   ghc-options:        -Wall -O2 -fwarn-tabs
   cc-options:         -funroll-loops
+  if os(windows)
+    cc-options:         -DNGETRUSAGE
   build-depends:      base >=4.6 && <4.8
   default-language:   Haskell2010
   Hs-source-dirs:     src


### PR DESCRIPTION
To avoid compilation error "sys/resource.h: No such file or directory".

This change let's me compile the library on my Windows machine and run the example from the documentation in a compiled program. But ghci crashes when calling `solve`. I didn't test further.